### PR TITLE
Show announcements date in top news carousel

### DIFF
--- a/Resources/Private/Templates/TopShort.html
+++ b/Resources/Private/Templates/TopShort.html
@@ -8,7 +8,7 @@
 			<div class="MediaSlide-Wrap columns">
 				<div class="MediaSlide-Body">
 					<h3 class="MediaSlide-Title">
-						<f:if condition="{date} == 123">
+						<f:if condition="{node.nodeType.name} == 'Sfi.News:Announcement'">
 							<span class="MediaSlide-Date"><s:date format="{configuration.dateFormat}">{date}</s:date></span>
 						</f:if>
 						{title}


### PR DESCRIPTION
Hi, Dmitriy
I've try to solve that ticket. Sasha said that date near the text at the same line is normal. So I think that designer's approve I have. 
Pls, review that code.